### PR TITLE
Fix for invalid authenticator name in multi-option steps

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.application.authentication/src/main/java/org/wso2/carbon/identity/data/publisher/application/authentication/AbstractAuthenticationDataPublisher.java
+++ b/components/org.wso2.carbon.identity.data.publisher.application.authentication/src/main/java/org/wso2/carbon/identity/data/publisher/application/authentication/AbstractAuthenticationDataPublisher.java
@@ -98,7 +98,11 @@ public abstract class AbstractAuthenticationDataPublisher extends AbstractIdenti
         authenticationData.setForcedAuthn(context.isForceAuthenticate());
         authenticationData.setPassive(context.isPassiveAuthenticate());
         authenticationData.setInitialLogin(false);
-        authenticationData.setAuthenticator(context.getCurrentAuthenticator());
+
+        String authenticator = AuthnDataPublisherUtils.replaceIfNotAvailable(AuthPublisherConstants.CONFIG_PREFIX +
+                AuthPublisherConstants.AUTHENTICATOR_NAME, (String) params.get(FrameworkConstants.AUTHENTICATOR));
+        authenticationData.setAuthenticator(authenticator);
+
         authenticationData.setSuccess(true);
         authenticationData.setStepNo(step);
         authenticationData.addParameter(AuthPublisherConstants.TENANT_ID, AuthnDataPublisherUtils
@@ -166,7 +170,9 @@ public abstract class AbstractAuthenticationDataPublisher extends AbstractIdenti
         authenticationData.setForcedAuthn(context.isForceAuthenticate());
         authenticationData.setPassive(context.isPassiveAuthenticate());
         authenticationData.setInitialLogin(false);
-        authenticationData.setAuthenticator(context.getCurrentAuthenticator());
+        String authenticator = AuthnDataPublisherUtils.replaceIfNotAvailable(AuthPublisherConstants.CONFIG_PREFIX +
+                AuthPublisherConstants.AUTHENTICATOR_NAME, (String) params.get(FrameworkConstants.AUTHENTICATOR));
+        authenticationData.setAuthenticator(authenticator);
         authenticationData.setSuccess(false);
         authenticationData.setStepNo(step);
         // Should publish the event to both SP tenant domain and the tenant domain of the user who did the login

--- a/components/org.wso2.carbon.identity.data.publisher.application.authentication/src/main/java/org/wso2/carbon/identity/data/publisher/application/authentication/AuthPublisherConstants.java
+++ b/components/org.wso2.carbon.identity.data.publisher.application.authentication/src/main/java/org/wso2/carbon/identity/data/publisher/application/authentication/AuthPublisherConstants.java
@@ -49,6 +49,7 @@ public class AuthPublisherConstants {
     public static final String NOT_AVAILABLE = "NOT_AVAILABLE";
     public static final String SHA_256 = "SHA-256";
     public static final String USER_AGENT = "User-Agent";
+    public static final String AUTHENTICATOR_NAME = "authenticatorName";
 
     // Session status codes
     public static final int SESSION_CREATION_STATUS = 1;


### PR DESCRIPTION
Part of the fix for wso2/product-is#2245

When we are using the AuthenticationContext.getCurrentAuthenticator() method at the publisher proxy to get the authenticator name for multi option step configuration scenario this is evaluated as null since this value is explicitly set for only few scenarios.

With this fix, we pass the name as a property from abstract authenticator when calling the publisher proxy, and update the proxy to get the authenticator name from the property instead of context's current authenticator.