### PR TITLE
Add tenant domain details to the authentication data object for a authenticated user

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtils.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtils.java
@@ -178,7 +178,7 @@ public class AnalyticsLoginDataPublisherUtils {
 
         AuthenticationData authenticationData = new AuthenticationData();
         Object userObj = params.get(FrameworkConstants.AnalyticsAttributes.USER);
-        setUserDataForAuthentication(status, authenticationData, userObj);
+        setUserDataForAuthentication(authenticationData, userObj);
 
         authenticationData = setIdpDataAndStepForAuthentication(context, status, authenticationData);
 
@@ -260,16 +260,14 @@ public class AnalyticsLoginDataPublisherUtils {
         return authenticationData;
     }
 
-    private static void setUserDataForAuthentication(AuthenticatorStatus status, AuthenticationData authenticationData,
-                                                     Object userObj) {
+    private static void setUserDataForAuthentication(AuthenticationData authenticationData,
+            Object userObj) {
 
         if (userObj instanceof AuthenticatedUser) {
             AuthenticatedUser user = (AuthenticatedUser) userObj;
             authenticationData.setUsername(user.getUserName());
-            if (status == AuthenticatorStatus.FAIL) {
-                authenticationData.setTenantDomain(user.getTenantDomain());
-                authenticationData.setUserStoreDomain(user.getUserStoreDomain());
-            }
+            authenticationData.setTenantDomain(user.getTenantDomain());
+            authenticationData.setUserStoreDomain(user.getUserStoreDomain());
         }
     }
 

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/test/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtilsTest.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/test/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtilsTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.data.publisher.authentication.analytics.login;
+
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.data.publisher.authentication.analytics.login.model.AuthenticationData;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.event.Event;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+
+@PrepareForTest({ AuthenticationContext.class })
+public class AnalyticsLoginDataPublisherUtilsTest {
+
+    private static final String TENANT_DOMAIN = "abc.com";
+    @Mock
+    HttpServletRequest mockHttpServletRequest;
+    @Mock
+    AuthenticationContext mockAuthenticationContext;
+    @Mock
+    SessionContext mockSessionContext;
+
+    @BeforeTest
+    public void setUp() {
+        initMocks(this);
+        when(mockAuthenticationContext.getExternalIdP()).thenReturn(null);
+    }
+
+    @DataProvider(name = "getEvent")
+    public Object[][] getEvent() {
+        Map<String, Object> param = new HashMap<>();
+        Object userObj = new AuthenticatedUser();
+        ((AuthenticatedUser) userObj).setTenantDomain(TENANT_DOMAIN);
+        param.put(FrameworkConstants.AnalyticsAttributes.USER, userObj);
+        Event event = createEvent(mockHttpServletRequest, mockAuthenticationContext, mockSessionContext, param,
+                IdentityEventConstants.EventName.AUTHENTICATION_STEP_SUCCESS);
+
+        return new Object[][] {
+                { event, TENANT_DOMAIN},
+                };
+    }
+
+    @Test(dataProvider = "getEvent")
+    public void testBuildAuthnDataForAuthnStep(Event event, String expectedTenantDomain) {
+
+        AuthenticationData authenticationData = AnalyticsLoginDataPublisherUtils.buildAuthnDataForAuthnStep(event);
+        Assert.assertEquals(authenticationData.getTenantDomain(), expectedTenantDomain);
+    }
+
+    @Test(dataProvider = "getEvent")
+    public void testBuildAuthnDataForAuthentication(Event event, String expectedTenantDomain) {
+
+        AuthenticationData authenticationData = AnalyticsLoginDataPublisherUtils.buildAuthnDataForAuthentication(event);
+        Assert.assertEquals(authenticationData.getTenantDomain(), expectedTenantDomain);
+    }
+
+    private Event createEvent(HttpServletRequest request, AuthenticationContext context, SessionContext sessionContext,
+            Map<String, Object> params, IdentityEventConstants.EventName eventName) {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.REQUEST, request);
+        eventProperties.put(IdentityEventConstants.EventProperty.CONTEXT, context);
+        if (sessionContext != null) {
+            eventProperties.put(IdentityEventConstants.EventProperty.SESSION_CONTEXT, sessionContext);
+        }
+        eventProperties.put(IdentityEventConstants.EventProperty.PARAMS, params);
+        return new Event(eventName.name(), eventProperties);
+    }
+}

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/test/resources/testng.xml
@@ -21,6 +21,7 @@
         <!--<parameter name="log-level" value="debug"/>-->
         <classes>
             <class name="org.wso2.carbon.identity.data.publisher.authentication.analytics.login.AnalyticsLoginDataPublishHandlerTest"/>
+            <class name="org.wso2.carbon.identity.data.publisher.authentication.analytics.login.AnalyticsLoginDataPublisherUtilsTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
The tenant domain should be added to the authentication data object when authentication failed and succeeded both.
Fix : wso2/product-is#6952