### PR TITLE
[Public] add contextual info to audit logs

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.authentication.audit/pom.xml
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.audit/pom.xml
@@ -73,6 +73,16 @@
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -96,6 +106,7 @@
 
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
+                            org.slf4j; version="${org.slf4j.imp.pkg.version.range}",
                             org.wso2.carbon.identity.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.handler; version="${carbon.identity.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.audit/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/audit/AuthenticationAuditLoggingHandler.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.audit/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/audit/AuthenticationAuditLoggingHandler.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.data.publisher.authentication.audit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.log4j.MDC;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
@@ -43,6 +44,11 @@ public class AuthenticationAuditLoggingHandler extends AbstractEventHandler {
 
     private static final Log AUDIT_LOG = CarbonConstants.AUDIT_LOG;
     private static final Log LOG = LogFactory.getLog(AuthenticationAuditLoggingHandler.class);
+
+    public static final String USER_AGENT_QUERY_KEY = "User-Agent";
+    public static final String USER_AGENT_KEY = "User Agent";
+    public static final String REMOTE_ADDRESS_QUERY_KEY = "remoteAddress";
+    public static final String REMOTE_ADDRESS_KEY = "RemoteAddress";
 
     @Override
     public String getName() {
@@ -97,6 +103,7 @@ public class AuthenticationAuditLoggingHandler extends AbstractEventHandler {
                 + "\",\"" + "RelyingParty" + "\" : \"" + authenticationData.getRelyingParty()
                 + "\",\"" + "AuthenticatedIdP" + "\" : \"" + authenticationData.getAuthenticatedIdps()
                 + "\"";
+        addContextualInfo(auditData);
 
         AUDIT_LOG.info(String.format(
                 FrameworkConstants.AUDIT_MESSAGE,
@@ -114,6 +121,7 @@ public class AuthenticationAuditLoggingHandler extends AbstractEventHandler {
                 + "\",\"" + "RelyingParty" + "\" : \"" + authenticationData.getRelyingParty()
                 + "\",\"" + "StepNo" + "\" : \"" + authenticationData.getStepNo()
                 + "\"";
+        addContextualInfo(auditData);
 
         AUDIT_LOG.info(String.format(
                 FrameworkConstants.AUDIT_MESSAGE,
@@ -134,6 +142,7 @@ public class AuthenticationAuditLoggingHandler extends AbstractEventHandler {
                 + "\",\"" + "RelyingParty" + "\" : \"" + authenticationData.getRelyingParty()
                 + "\",\"" + "AuthenticatedIdPs" + "\" : \"" + authenticationData.getAuthenticatedIdps()
                 + "\"";
+        addContextualInfo(auditData);
 
         AUDIT_LOG.info(String.format(
                 FrameworkConstants.AUDIT_MESSAGE,
@@ -150,6 +159,7 @@ public class AuthenticationAuditLoggingHandler extends AbstractEventHandler {
                 + "\",\"" + "RelyingParty" + "\" : \"" + authenticationData.getRelyingParty()
                 + "\",\"" + "StepNo" + "\" : \"" + authenticationData.getStepNo()
                 + "\"";
+        addContextualInfo(auditData);
 
         AUDIT_LOG.info(String.format(
                 FrameworkConstants.AUDIT_MESSAGE,
@@ -226,5 +236,12 @@ public class AuthenticationAuditLoggingHandler extends AbstractEventHandler {
         }
 
         return false;
+    }
+
+    private void addContextualInfo(String data) {
+
+        data += "\",\"" + USER_AGENT_KEY + "\" : \"" + MDC.get(USER_AGENT_QUERY_KEY)
+                + "\",\"" + REMOTE_ADDRESS_KEY + "\" : \"" + MDC.get(REMOTE_ADDRESS_QUERY_KEY)
+                + "\"";
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,18 @@
                 <artifactId>pax-logging-api</artifactId>
                 <version>${pax.logging.api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.api.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j.api.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <repositories>
@@ -328,6 +340,8 @@
         <imp.pkg.version.data.publisher.authentication>[5.0.0, 6.0.0)</imp.pkg.version.data.publisher.authentication>
         <!-- Pax Logging Version -->
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
+        <slf4j.api.version>1.6.1</slf4j.api.version>
+        <org.slf4j.imp.pkg.version.range>[1.5.5,2.0.0)</org.slf4j.imp.pkg.version.range>
     </properties>
 
 </project>


### PR DESCRIPTION
**Fix** https://github.com/wso2-extensions/identity-data-publisher-authentication/pull/84
**Resolves** wso2/product-is#9119

**Description**
Added contextual information such as logged-in user, SP name, the remote IP address. Client user agent to audit logs for authentication-related events.