### PR TITLE
Fix tenant domain null in audit logs for federated IDPs

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.authentication.audit/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/audit/AuthenticationAuditLoggerUtils.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.audit/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/audit/AuthenticationAuditLoggerUtils.java
@@ -144,6 +144,9 @@ public class AuthenticationAuditLoggerUtils {
             if (localIDPData != null) {
                 tenantDomain = localIDPData.getUser().getTenantDomain();
             }
+            if (StringUtils.isBlank(tenantDomain)) {
+                tenantDomain = context.getTenantDomain();
+            }
         }
         return tenantDomain;
     }


### PR DESCRIPTION
### Proposed changes in this pull request

- The tenant domain is logged as null in "Login" action at audit log. This fix has not been added to the master branch instead it is only added to the support branch.
- The relevant support PR can be found at https://github.com/wso2-support/identity-data-publisher-authentication/pull/22.
- Fixes: https://github.com/wso2/product-is/issues/11861.

### Follow up actions

- Upgrade the product-is to the released version (after this PR is merged).
