### PR TITLE
Fix tenant domain not null and user name not shown in audit logs

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.authentication.audit/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/audit/AuthenticationAuditLoggerConstants.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.audit/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/audit/AuthenticationAuditLoggerConstants.java
@@ -29,6 +29,7 @@ public class AuthenticationAuditLoggerConstants {
     public static final String AUDIT_AUTHENTICATION = "auditAuth";
 
     public static final String AUTHENTICATION_AUDIT_LOGGER_ENABLED = "authenticationAuditLogger.enable";
+    public static final String AUTHENTICATION_AUDIT_LOGGER_USERNAME_ENABLED = "authenticationAuditLogger.userName.attribute";
 
     private AuthenticationAuditLoggerConstants(){
 

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.audit/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/audit/AuthenticationAuditLoggingHandler.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.audit/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/audit/AuthenticationAuditLoggingHandler.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.data.publisher.authentication.audit;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.slf4j.MDC;
@@ -61,6 +62,7 @@ public class AuthenticationAuditLoggingHandler extends AbstractEventHandler {
     public void handleEvent(Event event) throws IdentityEventException {
 
         boolean isEnabled = isAuthenticationAuditLoggingEnabled(event);
+        boolean isUserNameEnabled = isAuditLoggerUserNameEnabled(event);
 
         if (!isEnabled) {
             return;
@@ -69,22 +71,22 @@ public class AuthenticationAuditLoggingHandler extends AbstractEventHandler {
         AuthenticationAuditData authenticationAuditData = null;
         if (IdentityEventConstants.EventName.AUTHENTICATION_STEP_SUCCESS.name().equals(event.getEventName())) {
             authenticationAuditData = AuthenticationAuditLoggerUtils.createAuthenticationAudiDataObject(event,
-                    AuthenticationAuditLoggerConstants.AUDIT_AUTHENTICATION_STEP);
+                    AuthenticationAuditLoggerConstants.AUDIT_AUTHENTICATION_STEP, isUserNameEnabled);
             doPublishAuthenticationStepSuccess(authenticationAuditData);
 
         } else if (IdentityEventConstants.EventName.AUTHENTICATION_STEP_FAILURE.name().equals(event.getEventName())) {
             authenticationAuditData = AuthenticationAuditLoggerUtils.createAuthenticationAudiDataObject(event,
-                    AuthenticationAuditLoggerConstants.AUDIT_AUTHENTICATION_STEP);
+                    AuthenticationAuditLoggerConstants.AUDIT_AUTHENTICATION_STEP, isUserNameEnabled);
             doPublishAuthenticationStepFailure(authenticationAuditData);
 
         } else if (IdentityEventConstants.EventName.AUTHENTICATION_SUCCESS.name().equals(event.getEventName())) {
             authenticationAuditData = AuthenticationAuditLoggerUtils.createAuthenticationAudiDataObject(event,
-                    AuthenticationAuditLoggerConstants.AUDIT_AUTHENTICATION);
+                    AuthenticationAuditLoggerConstants.AUDIT_AUTHENTICATION, isUserNameEnabled);
             doPublishAuthenticationSuccess(authenticationAuditData);
 
         } else if (IdentityEventConstants.EventName.AUTHENTICATION_FAILURE.name().equals(event.getEventName())) {
             authenticationAuditData = AuthenticationAuditLoggerUtils.createAuthenticationAudiDataObject(event,
-                    AuthenticationAuditLoggerConstants.AUDIT_AUTHENTICATION);
+                    AuthenticationAuditLoggerConstants.AUDIT_AUTHENTICATION, isUserNameEnabled);
             doPublishAuthenticationFailure(authenticationAuditData);
 
         } else if (IdentityEventConstants.EventName.SESSION_TERMINATE.name().equals(event.getEventName())) {
@@ -92,6 +94,19 @@ public class AuthenticationAuditLoggingHandler extends AbstractEventHandler {
         } else {
             LOG.error("Event " + event.getEventName() + " cannot be handled");
         }
+    }
+
+    private boolean isAuditLoggerUserNameEnabled(Event event) throws IdentityEventException {
+
+        boolean isEnabled = false;
+        if (this.configs.getModuleProperties() != null) {
+            String handlerEnabled = this.configs.getModuleProperties().getProperty(AuthenticationAuditLoggerConstants.
+                    AUTHENTICATION_AUDIT_LOGGER_USERNAME_ENABLED);
+            if (StringUtils.isNotBlank(handlerEnabled) && handlerEnabled.equals("username")) {
+                isEnabled = true;
+            }
+        }
+        return isEnabled;
     }
 
     protected void doPublishAuthenticationStepSuccess(AuthenticationAuditData authenticationData) {


### PR DESCRIPTION
**Purpose**
Tenant domain is null in audit logs and log use name in audit logs for logging with federated Idps.

Fixes https://github.com/wso2/product-is/issues/11861
Fixes https://github.com/wso2/product-is/issues/11911