### PR TITLE
Change analytics configurations for ELK support

### DIFF
--- a/features/org.wso2.carbon.identity.data.publisher.application.authentication.server.feature/resources/IsAnalytics-Publisher-wso2event-AuthenticationData.xml
+++ b/features/org.wso2.carbon.identity.data.publisher.application.authentication.server.feature/resources/IsAnalytics-Publisher-wso2event-AuthenticationData.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<eventPublisher name="IsAnalytics-Publisher-wso2event-AuthenticationData" statistics="disable" trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
+<eventPublisher
+  name="IsAnalytics-Publisher-wso2event-AuthenticationData"
+  statistics="disable" trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
   <from streamName="org.wso2.is.analytics.stream.OverallAuthentication" version="1.0.0"/>
-  <mapping customMapping="disable" type="wso2event"/>
-  <to eventAdapterType="wso2event">
-    <property name="username">admin</property>
-    <property name="protocol">thrift</property>
-    <property name="publishingMode">non-blocking</property>
-    <property name="publishTimeout">0</property>
-    <property name="receiverURL">tcp://localhost:7612</property>
-    <property encrypted="false" name="password">admin</property>
+  <mapping customMapping="disable" type="json"/>
+  <to eventAdapterType="logger">
+    <property name="uniqueId">auth</property>
   </to>
 </eventPublisher>

--- a/features/org.wso2.carbon.identity.data.publisher.application.authentication.server.feature/resources/IsAnalytics-Publisher-wso2event-SessionData.xml
+++ b/features/org.wso2.carbon.identity.data.publisher.application.authentication.server.feature/resources/IsAnalytics-Publisher-wso2event-SessionData.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<eventPublisher name="IsAnalytics-Publisher-wso2event-SessionData" statistics="disable" trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
-  <from streamName="org.wso2.is.analytics.stream.OverallSession" version="1.0.0"/>
-  <mapping customMapping="disable" type="wso2event"/>
-  <to eventAdapterType="wso2event">
-    <property name="username">admin</property>
-    <property name="protocol">thrift</property>
-    <property name="publishingMode">non-blocking</property>
-    <property name="publishTimeout">0</property>
-    <property name="receiverURL">tcp://localhost:7612</property>
-    <property encrypted="false" name="password">admin</property>
+<eventPublisher
+  name="IsAnalytics-Publisher-wso2event-SessionData"
+  statistics="disable" trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
+  <from streamName="org.wso2.is.analytics.stream.OverallSession" version="1.0.1"/>
+  <mapping customMapping="disable" type="json"/>
+  <to eventAdapterType="logger">
+    <property name="uniqueId">session</property>
   </to>
 </eventPublisher>


### PR DESCRIPTION
From IS 5.12 onwards, we only recommend ELK based analytics for Identity Server on-prem analytics. This PR changes default configurations to enable ELK-based analytics.