### PR TITLE
[5.3.x] Fix RemoteAddress missing issue for logout in audit logs

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.authentication.audit/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/audit/AuthenticationAuditLoggingHandler.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.audit/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/audit/AuthenticationAuditLoggingHandler.java
@@ -183,6 +183,7 @@ public class AuthenticationAuditLoggingHandler extends AbstractEventHandler {
                 + "\",\"" + "RelyingParty" + "\" : \"" + context.getRelyingParty()
                 + "\",\"" + "AuthenticatedIdPs" + "\" : \"" + authenticatedIDPs
                 + "\"";
+        auditData = addRemoteAddressAndAgent(auditData);
 
         String idpName = null;
         ExternalIdPConfig externalIdPConfig = context.getExternalIdP();
@@ -259,6 +260,14 @@ public class AuthenticationAuditLoggingHandler extends AbstractEventHandler {
         data += ",\"" + USER_AGENT_KEY + "\" : \"" + MDC.get(USER_AGENT_QUERY_KEY)
                 + "\",\"" + REMOTE_ADDRESS_KEY + "\" : \"" + MDC.get(REMOTE_ADDRESS_QUERY_KEY)
                 + "\",\"" + USER_STORE_DOMAIN_KEY + "\" : \"" + authenticationData.getUserStoreDomain()
+                + "\"";
+        return data;
+    }
+
+    private String addRemoteAddressAndAgent(String data) {
+
+        data += ",\"" + USER_AGENT_KEY + "\" : \"" + MDC.get(USER_AGENT_QUERY_KEY)
+                + "\",\"" + REMOTE_ADDRESS_KEY + "\" : \"" + MDC.get(REMOTE_ADDRESS_QUERY_KEY)
                 + "\"";
         return data;
     }


### PR DESCRIPTION
This PR fixes an issue where RemoteAddress details are missing in the audit logs for logout operation.

Related issue: https://github.com/wso2/product-apim/issues/12851