### PR TITLE
Introduce a config to enable/disable publishing multiple login evens for SaaS Apps

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublishConstants.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublishConstants.java
@@ -34,6 +34,8 @@ public class AnalyticsLoginDataPublishConstants {
     public static final String OVERALL_EVENT = "overall";
 
     public static final String ANALYTICS_LOGIN_DATA_PUBLISHER_ENABLED = "analyticsLoginDataPublisher.enable";
+    public static final String ANALYTICS_LOGIN_DATA_PUBLISHER_ENABLE_MULTIPLE_EVENT_PUBLISHING_FOR_SAAS_APPS =
+            "analyticsLoginDataPublisher.enableMultipleEventPublishingForSaasApps";
     public static final String ANALYTICS_LOGIN_DATA_PUBLISHER_V110_ENABLED = "analyticsLoginDataPublisherV110.enable";
     public static final long LONG_NOT_AVAILABLE = 0;
     public static final String ANALYTICS_LOGIN_PUBLISHER_V110_NAME = "analyticsLoginDataPublisherV110";


### PR DESCRIPTION
**Related Issue**
https://github.com/wso2/product-is/issues/13520

**Description**
When a tenant user logs in from a SaaS app the currently we are to trigger two login events, where one is for the SP existing tenant and the other one is for the user existing tenant. 

This fix will introduce a new flag to avoid the publishing of multiple login events per one SaaS app login. 

```
[identity_mgt.analytics_login_data_publisher]
enableMultipleEventPublishingForSaasApps=false
```


Without configuring this flag IS will behave in the previous manner and will publish two login events for SaaS app login of tenant user.

**Prerequisite**
- [x] https://github.com/wso2/carbon-identity-framework/pull/4027
