### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.application.authentication/pom.xml
+++ b/components/org.wso2.carbon.identity.data.publisher.application.authentication/pom.xml
@@ -59,7 +59,7 @@
             <artifactId>org.wso2.carbon.event.stream.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/pom.xml
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/pom.xml
@@ -78,7 +78,7 @@
             <artifactId>org.wso2.carbon.identity.data.publisher.application.authentication</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.session/pom.xml
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.session/pom.xml
@@ -79,8 +79,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.testutil</artifactId>
         </dependency>
     </dependencies>
 
@@ -137,6 +141,10 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
                 </configuration>
             </plugin>
             <plugin>

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.audit/pom.xml
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.audit/pom.xml
@@ -70,7 +70,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,12 @@
 
             <!-- Testing related dependencies -->
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>
@@ -115,7 +121,7 @@
             </dependency>
             <!-- Pax Logging -->
             <dependency>
-                <groupId>org.ops4j.pax.logging</groupId>
+                <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-api</artifactId>
                 <version>${pax.logging.api.version}</version>
             </dependency>
@@ -229,10 +235,10 @@
         <carbon.kernel.version>4.5.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.5.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.version>5.20.259</carbon.identity.framework.version>
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
         <carbon.identity.data.publisher.package.export.version>${project.version}</carbon.identity.data.publisher.package.export.version>
-        <carbon.identity.data.publisher.package.import.version.range>[5.3.0, 6.0.0)</carbon.identity.data.publisher.package.import.version.range>
-        <carbon.identity.framework.package.import.version.range>[5.14.67, 6.0.0)</carbon.identity.framework.package.import.version.range>
+        <carbon.identity.data.publisher.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.data.publisher.package.import.version.range>
+        <carbon.identity.framework.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.package.import.version.range>
         <carbon.analytics-common.version>5.2.10</carbon.analytics-common.version>
         <carbon.analytics-common.imp.pkg.version.range>[5.2.10,6.0.0)</carbon.analytics-common.imp.pkg.version.range>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
@@ -248,16 +254,16 @@
         <org.powermock.version>1.6.6</org.powermock.version>
 
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
-        <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
-        <carbon.identity.package.import.version.range>[5.0.0, 6.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.framework.imp.pkg.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.imp.pkg.version.range>
+        <carbon.identity.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.package.import.version.range>
         <axiom.osgi.version.range>[1.2.11, 2.0.0)</axiom.osgi.version.range>
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
-        <imp.pkg.version.data.publisher.authentication>[5.0.0, 6.0.0)</imp.pkg.version.data.publisher.authentication>
+        <imp.pkg.version.data.publisher.authentication>[6.0.0, 7.0.0)</imp.pkg.version.data.publisher.authentication>
         <!-- Pax Logging Version -->
-        <pax.logging.api.version>1.10.1</pax.logging.api.version>
+        <pax.logging.api.version>2.1.0-wso2v4</pax.logging.api.version>
         <slf4j.api.version>1.6.1</slf4j.api.version>
         <org.slf4j.imp.pkg.version.range>[1.5.5,2.0.0)</org.slf4j.imp.pkg.version.range>
     </properties>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

The `org.ops4j.pax.logging` dependency is upgraded to `org.wso2.org.ops4j.pax.logging` for the log4j upgrade.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16