### PR TITLE
Improve authentication data to contain b2b login data

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/pom.xml
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/pom.xml
@@ -133,11 +133,13 @@
                             org.wso2.carbon.identity.core.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.bean.context; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.idp.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.data.publisher.application.authentication; version="${imp.pkg.version.data.publisher.authentication}",
                             org.wso2.carbon.user.core.tenant; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.organization.management.*; version="${identity.organization.management.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.application.common.*; version="${carbon.identity.framework.imp.pkg.version.range}"
+                            org.wso2.carbon.identity.application.common.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.data.publisher.authentication.analytics.login.internal,

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/pom.xml
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.user.api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.core</artifactId>
         </dependency>
@@ -81,6 +85,10 @@
             <artifactId>jacoco-maven-plugin</artifactId>
             <version>${jacoco.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -115,6 +123,7 @@
                             org.wso2.carbon.identity.event.bean; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.user.core; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.common; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.util; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.model; version="${carbon.identity.framework.imp.pkg.version.range}",
@@ -126,6 +135,9 @@
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.data.publisher.application.authentication; version="${imp.pkg.version.data.publisher.authentication}",
                             org.wso2.carbon.user.core.tenant; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.identity.organization.management.*; version="${identity.organization.management.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.common.*; version="${carbon.identity.framework.imp.pkg.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.data.publisher.authentication.analytics.login.internal,

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublishHandlerV110.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublishHandlerV110.java
@@ -49,7 +49,7 @@ import java.util.UUID;
 public class AnalyticsLoginDataPublishHandlerV110 extends AbstractEventHandler {
 
     private static final Log LOG = LogFactory.getLog(AnalyticsLoginDataPublishHandlerV110.class);
-    private static final int PAYLOAD_LENGTH = 34;
+    private static final int PAYLOAD_LENGTH = 38;
 
     @Override
     public String getName() {
@@ -151,9 +151,14 @@ public class AnalyticsLoginDataPublishHandlerV110 extends AbstractEventHandler {
                 AnalyticsLoginDataPublisherUtils.replaceIfStringNotAvailable(authenticationData.getUserResidingOrgId());
         payloadData[28] = AnalyticsLoginDataPublisherUtils.replaceIfStringNotAvailable(
                 authenticationData.getServiceProviderResidingOrgId());
+        payloadData[29] = authenticationData.isOrganizationLogin();
+        payloadData[30] = authenticationData.isSharedAppLogin();
+
+        payloadData[31] = AnalyticsLoginDataPublisherUtils.replaceIfNotAvailable(authenticationData.getIdps());
+        payloadData[32] = AnalyticsLoginDataPublisherUtils.replaceIfStringNotAvailable(authenticationData.getAuthenticator());
         List<String> customParams = authenticationData.getCustomParams();
         for (int i = 0; i < customParams.size(); i++) {
-            payloadData[29 + i] = customParams.get(i);
+            payloadData[33 + i] = customParams.get(i);
         }
 
         if (LOG.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublishHandlerV110.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublishHandlerV110.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.List;
 import java.util.UUID;
@@ -48,7 +49,7 @@ import java.util.UUID;
 public class AnalyticsLoginDataPublishHandlerV110 extends AbstractEventHandler {
 
     private static final Log LOG = LogFactory.getLog(AnalyticsLoginDataPublishHandlerV110.class);
-    private static final int PAYLOAD_LENGTH = 31;
+    private static final int PAYLOAD_LENGTH = 34;
 
     @Override
     public String getName() {
@@ -96,11 +97,11 @@ public class AnalyticsLoginDataPublishHandlerV110 extends AbstractEventHandler {
 
         String roleList = null;
         if (FrameworkConstants.LOCAL_IDP_NAME.equalsIgnoreCase(authenticationData.getIdentityProviderType())) {
-            roleList = getCommaSeparatedUserRoles(authenticationData.getUserStoreDomain() + "/" +
-                    authenticationData.getUsername(), authenticationData.getTenantDomain());
+            roleList = getCommaSeparatedUserRoles(UserCoreUtil.addDomainToName(authenticationData.getUsername(),
+                    authenticationData.getUserStoreDomain()), authenticationData.getTenantDomain());
         } else if (StringUtils.isNotEmpty(authenticationData.getLocalUsername())) {
-            roleList = getCommaSeparatedUserRoles(authenticationData.getUserStoreDomain() + "/" +
-                    authenticationData.getLocalUsername(), authenticationData.getTenantDomain());
+            roleList = getCommaSeparatedUserRoles(UserCoreUtil.addDomainToName(authenticationData.getLocalUsername(),
+                    authenticationData.getUserStoreDomain()), authenticationData.getTenantDomain());
         }
 
         Object[] payloadData = new Object[PAYLOAD_LENGTH];
@@ -144,10 +145,15 @@ public class AnalyticsLoginDataPublishHandlerV110 extends AbstractEventHandler {
         payloadData[24] = AnalyticsLoginDataPublisherUtils.replaceIfLongNotAvailable(authenticationData.getDuration());
         payloadData[25] =
                 AnalyticsLoginDataPublisherUtils.replaceIfStringNotAvailable(authenticationData.getErrorCode());
-
+        payloadData[26] =
+                AnalyticsLoginDataPublisherUtils.replaceIfStringNotAvailable(authenticationData.getUserLoginOrgId());
+        payloadData[27] =
+                AnalyticsLoginDataPublisherUtils.replaceIfStringNotAvailable(authenticationData.getUserResidingOrgId());
+        payloadData[28] = AnalyticsLoginDataPublisherUtils.replaceIfStringNotAvailable(
+                authenticationData.getServiceProviderResidingOrgId());
         List<String> customParams = authenticationData.getCustomParams();
         for (int i = 0; i < customParams.size(); i++) {
-            payloadData[26 + i] = customParams.get(i);
+            payloadData[29 + i] = customParams.get(i);
         }
 
         if (LOG.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtils.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtils.java
@@ -199,18 +199,18 @@ public class AnalyticsLoginDataPublisherUtils {
         if (resolvePrimaryTenantDomain) {
             // Resolve SP domain first; reuse the result for user domain when both are identical
             // (most common case) to avoid a second call.
-            String resolvedSp = StringUtils.isNotBlank(spTenantDomain)
+            String resolvedSpTenantDomain = StringUtils.isNotBlank(spTenantDomain)
                     ? getPrimaryOrgTenantDomain(spTenantDomain) : spTenantDomain;
-            String resolvedUser;
+            String resolvedUserTenantDomain;
             if (StringUtils.isNotBlank(userTenantDomain)) {
-                resolvedUser = userTenantDomain.equals(spTenantDomain)
-                        ? resolvedSp
+                resolvedUserTenantDomain = userTenantDomain.equals(spTenantDomain)
+                        ? resolvedSpTenantDomain
                         : getPrimaryOrgTenantDomain(userTenantDomain);
             } else {
-                resolvedUser = userTenantDomain;
+                resolvedUserTenantDomain = userTenantDomain;
             }
-            spTenantDomain = resolvedSp;
-            userTenantDomain = resolvedUser;
+            spTenantDomain = resolvedSpTenantDomain;
+            userTenantDomain = resolvedUserTenantDomain;
         }
 
         if (AuthenticatorStatus.PASS == status) {

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtils.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtils.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.data.publisher.authentication.analytics.login;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorStatus;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
@@ -28,18 +29,35 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.U
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.data.publisher.application.authentication.AuthPublisherConstants;
 import org.wso2.carbon.identity.data.publisher.application.authentication.AuthnDataPublisherUtils;
+import org.wso2.carbon.identity.data.publisher.authentication.analytics.login.internal.AnalyticsLoginDataPublishDataHolder;
 import org.wso2.carbon.identity.data.publisher.authentication.analytics.login.model.AuthenticationData;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.user.api.Tenant;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
@@ -57,14 +75,30 @@ public class AnalyticsLoginDataPublisherUtils {
     private static final String APPLICATION_DOMAIN = "Application";
     private static final String WORKFLOW_DOMAIN = "Workflow";
     private static final String INTERNAL_EVERYONE_ROLE = "Internal/everyone";
+    public static final String ORGANIZATION_AUTHENTICATOR = "OrganizationAuthenticator";
+    public static final String ORG_ID = "orgId";
+    public static final String IS_FRAGMENT_APP = "isFragmentApp";
 
     /**
      * Build authentication data object for authentication step from event.
      *
-     * @param event
+     * @param event Event.
      * @return Authentication data object
      */
     public static AuthenticationData buildAuthnDataForAuthnStep(Event event) {
+
+        return buildAuthnDataForAuthnStep(event, false);
+    }
+
+    /**
+     * Build authentication data object for authentication step from event.
+     *
+     * @param event                      Event.
+     * @param resolvePrimaryTenantDomain if {@code true}, SP and user tenant domains are resolved
+     *                                   to the primary organisation's org-handle before publishing.
+     * @return Authentication data object
+     */
+    public static AuthenticationData buildAuthnDataForAuthnStep(Event event, boolean resolvePrimaryTenantDomain) {
 
         Map<String, Object> properties = event.getEventProperties();
         HttpServletRequest request = (HttpServletRequest) properties.get(IdentityEventConstants.EventProperty.REQUEST);
@@ -74,13 +108,16 @@ public class AnalyticsLoginDataPublisherUtils {
         AuthenticatorStatus status = (AuthenticatorStatus) properties.get(IdentityEventConstants.EventProperty.
                 AUTHENTICATION_STATUS);
 
+        // Tenant cache: avoids redundant DB lookups for the same domain within this call.
+        Map<String, Tenant> tenantCache = new HashMap<>();
+
         AuthenticationData authenticationData = new AuthenticationData();
         setIdpForAuthnStep(context, authenticationData);
         Object userObj = params.get(FrameworkConstants.AnalyticsAttributes.USER);
         boolean isInvalidUsername =
                 context.getProperty(IS_INVALID_USERNAME) != null && (boolean) context.getProperty(IS_INVALID_USERNAME);
         context.setProperty(IS_INVALID_USERNAME, null);
-        setUserDataForAuthnStep(authenticationData, userObj, isInvalidUsername);
+        setUserDataForAuthnStep(authenticationData, userObj, isInvalidUsername, context, tenantCache);
 
         Object isFederatedObj = params.get(FrameworkConstants.AnalyticsAttributes.IS_FEDERATED);
         setIdpTypeForAuthnStep(authenticationData, isFederatedObj);
@@ -104,7 +141,8 @@ public class AnalyticsLoginDataPublisherUtils {
         authenticationData.setSuccess(AuthenticatorStatus.PASS == status);
         authenticationData.setStepNo(context.getCurrentStep());
         authenticationData.setUsernameUserInput((String) context.getProperty(USERNAME_USER_INPUT));
-        setTenantDataForIdpStep(context, status, authenticationData);
+        setTenantDataForIdpStep(context, status, authenticationData, resolvePrimaryTenantDomain);
+        updateSpResidingData(context, authenticationData, tenantCache);
 
         authenticationData.addParameter(AuthPublisherConstants.RELYING_PARTY, context.getRelyingParty());
         return authenticationData;
@@ -119,7 +157,21 @@ public class AnalyticsLoginDataPublisherUtils {
      */
     public static AuthenticationData buildAuthnDataForAuthnStepV110(Event event) {
 
-        AuthenticationData authenticationData = buildAuthnDataForAuthnStep(event);
+        return buildAuthnDataForAuthnStepV110(event, false);
+    }
+
+    /**
+     * Build authentication data object for authentication step from event.
+     * This method is for new stream definition.
+     *
+     * @param event                      Event.
+     * @param resolvePrimaryTenantDomain if {@code true}, SP and user tenant domains are resolved
+     *                                   to the primary organisation's org-handle before publishing.
+     * @return Authentication data object
+     */
+    public static AuthenticationData buildAuthnDataForAuthnStepV110(Event event, boolean resolvePrimaryTenantDomain) {
+
+        AuthenticationData authenticationData = buildAuthnDataForAuthnStep(event, resolvePrimaryTenantDomain);
         Map<String, Object> properties = event.getEventProperties();
         AuthenticationContext context = (AuthenticationContext) properties.get(IdentityEventConstants.EventProperty.
                 CONTEXT);
@@ -132,26 +184,82 @@ public class AnalyticsLoginDataPublisherUtils {
     }
 
     private static void setTenantDataForIdpStep(AuthenticationContext context, AuthenticatorStatus status,
-                                                AuthenticationData authenticationData) {
+                                                AuthenticationData authenticationData,
+                                                boolean resolvePrimaryTenantDomain) {
+
+        String spTenantDomain = context.getTenantDomain();
+        String userTenantDomain = authenticationData.getTenantDomain();
+
+        if (resolvePrimaryTenantDomain) {
+            // Resolve SP domain first; reuse the result for user domain when both are identical
+            // (most common case) to avoid a second call.
+            String resolvedSp = StringUtils.isNotBlank(spTenantDomain)
+                    ? getPrimaryOrgTenantDomain(spTenantDomain) : spTenantDomain;
+            String resolvedUser;
+            if (StringUtils.isNotBlank(userTenantDomain)) {
+                resolvedUser = userTenantDomain.equals(spTenantDomain)
+                        ? resolvedSp
+                        : getPrimaryOrgTenantDomain(userTenantDomain);
+            } else {
+                resolvedUser = userTenantDomain;
+            }
+            spTenantDomain = resolvedSp;
+            userTenantDomain = resolvedUser;
+        }
 
         if (AuthenticatorStatus.PASS == status) {
             authenticationData.addParameter(AnalyticsLoginDataPublishConstants.TENANT_DOMAIN_NAMES,
-                    AuthnDataPublisherUtils.getTenantDomains(context.getTenantDomain(), authenticationData.
-                            getTenantDomain()));
+                    AuthnDataPublisherUtils.getTenantDomains(spTenantDomain, userTenantDomain));
         } else {
-            // Should publish the event to both SP tenant domain and the tenant domain of the user who did the login
-            // attempt
+            // Should publish the event to both SP tenant domain and the tenant domain of the user who did
+            // the login attempt.
             if (context.getSequenceConfig() != null && context.getSequenceConfig().getApplicationConfig() != null
                     && context.getSequenceConfig().getApplicationConfig().isSaaSApp()) {
                 authenticationData.addParameter(AnalyticsLoginDataPublishConstants.TENANT_DOMAIN_NAMES,
-                        AuthnDataPublisherUtils.getTenantDomains(context.getTenantDomain(), authenticationData.
-                                getTenantDomain()));
+                        AuthnDataPublisherUtils.getTenantDomains(spTenantDomain, userTenantDomain));
             } else {
                 authenticationData.addParameter(AnalyticsLoginDataPublishConstants.TENANT_DOMAIN_NAMES,
-                        AuthnDataPublisherUtils.getTenantDomains(context.getTenantDomain(), null));
+                        AuthnDataPublisherUtils.getTenantDomains(spTenantDomain, null));
+            }
+        }
+    }
+
+    /**
+     * Resolves the primary organisation's tenant domain (org-handle) for the given tenant domain.
+     * Delegates to {@link OrganizationManagementUtil#getRootOrgTenantDomainBySubOrgTenantDomain},
+     * which handles both root and sub-org tenants correctly.
+     * Falls back to returning {@code tenantDomain} unchanged on any error.
+     */
+    private static String getPrimaryOrgTenantDomain(String tenantDomain) {
+
+        try {
+            if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+                return tenantDomain;
             }
 
+            return OrganizationManagementUtil.getRootOrgTenantDomainBySubOrgTenantDomain(tenantDomain);
+        } catch (OrganizationManagementException e) {
+            LOG.warn("Failed to resolve primary org handle for domain: " + tenantDomain
+                    + ". Falling back to original domain.", e);
+            return tenantDomain;
         }
+    }
+
+    /**
+     * Loads a {@link Tenant} by domain, consulting {@code tenantCache} first so the same tenant
+     * is never fetched more than once per request.
+     */
+    private static Tenant loadTenantByDomain(String domain, Map<String, Tenant> tenantCache)
+            throws UserStoreException {
+
+        if (tenantCache.containsKey(domain)) {
+            return tenantCache.get(domain);
+        }
+        Tenant tenant = AnalyticsLoginDataPublishDataHolder.getInstance()
+                .getRealmService().getTenantManager().getTenantByDomain(domain);
+        // Cache even a null result so we don't hit the DB again for the same domain.
+        tenantCache.put(domain, tenant);
+        return tenant;
     }
 
     private static void setIdpTypeForAuthnStep(AuthenticationData authenticationData, Object isFederatedObj) {
@@ -167,7 +275,9 @@ public class AnalyticsLoginDataPublisherUtils {
         }
     }
 
-    private static void setUserDataForAuthnStep(AuthenticationData authenticationData, Object userObj, boolean isInvalidUsername) {
+    private static void setUserDataForAuthnStep(AuthenticationData authenticationData, Object userObj,
+                                                boolean isInvalidUsername, AuthenticationContext context,
+                                                Map<String, Tenant> tenantCache) {
 
         if (userObj instanceof User) {
             User user = (User) userObj;
@@ -182,6 +292,32 @@ public class AnalyticsLoginDataPublisherUtils {
             if (StringUtils.isEmpty(user.getUserName())) {
                 authenticationData.setUsername(user.getAuthenticatedSubjectIdentifier());
             }
+            try {
+                authenticationData.setUserId(user.getUserId());
+            } catch (UserIdNotFoundException e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Null user id is found in the AuthenticatedUser instance.");
+                }
+            }
+            updateUserOrgData(authenticationData, context, user, (User) userObj, tenantCache);
+        } else {
+            try {
+                // Resolve userId and organization data for unauthenticated users.
+                if (userObj instanceof User) {
+                    User user = (User) userObj;
+                    RealmService realmService = AnalyticsLoginDataPublishDataHolder.getInstance().getRealmService();
+                    AbstractUserStoreManager userStoreManager =
+                            (AbstractUserStoreManager) realmService.getTenantUserRealm(
+                                    IdentityTenantUtil.getTenantId(user.getTenantDomain())).getUserStoreManager();
+                    org.wso2.carbon.user.core.common.User user1 = userStoreManager.getUser(null,
+                            UserCoreUtil.addDomainToName(user.getUserName(), user.getUserStoreDomain()));
+                    authenticationData.setUserId(user1.getUserID());
+                    updateUserOrgData(authenticationData, context, null, (User) userObj, tenantCache);
+                }
+            } catch (UserStoreException e) {
+                throw new RuntimeException(e);
+            }
+
         }
     }
 
@@ -197,10 +333,23 @@ public class AnalyticsLoginDataPublisherUtils {
     /**
      * Build authentication data object for authentication from event.
      *
-     * @param event - triggerd event
+     * @param event  Event
      * @return AuthenticationData - authentication data object
      */
     public static AuthenticationData buildAuthnDataForAuthentication(Event event) {
+
+        return buildAuthnDataForAuthentication(event, false);
+    }
+
+    /**
+     * Build authentication data object for authentication from event.
+     *
+     * @param event                      Event
+     * @param resolvePrimaryTenantDomain if {@code true}, SP and user tenant domains are resolved
+     *                                   to the primary organisation's org-handle before publishing.
+     * @return AuthenticationData - authentication data object
+     */
+    public static AuthenticationData buildAuthnDataForAuthentication(Event event, boolean resolvePrimaryTenantDomain) {
 
         Map<String, Object> properties = event.getEventProperties();
         HttpServletRequest request = (HttpServletRequest) properties.get(IdentityEventConstants.EventProperty.REQUEST);
@@ -210,9 +359,12 @@ public class AnalyticsLoginDataPublisherUtils {
         AuthenticatorStatus status = (AuthenticatorStatus) properties.get(IdentityEventConstants.EventProperty.
                 AUTHENTICATION_STATUS);
 
+        // Tenant cache: avoids redundant DB lookups for the same domain within this call.
+        Map<String, Tenant> tenantCache = new HashMap<>();
+
         AuthenticationData authenticationData = new AuthenticationData();
         Object userObj = params.get(FrameworkConstants.AnalyticsAttributes.USER);
-        setUserDataForAuthentication(authenticationData, userObj);
+        setUserDataForAuthentication(authenticationData, userObj, context, tenantCache);
 
         authenticationData = setIdpDataAndStepForAuthentication(context, status, authenticationData);
 
@@ -235,7 +387,8 @@ public class AnalyticsLoginDataPublisherUtils {
         authenticationData.setForcedAuthn(context.isForceAuthenticate());
         authenticationData.setPassive(context.isPassiveAuthenticate());
         authenticationData.setUsernameUserInput((String) context.getProperty(USERNAME_USER_INPUT));
-        setTenantDataForAuthentication(context, status, authenticationData);
+        setTenantDataForAuthentication(context, status, authenticationData, resolvePrimaryTenantDomain);
+        updateSpResidingData(context, authenticationData, tenantCache);
 
         authenticationData.addParameter(AuthPublisherConstants.RELYING_PARTY, context.getRelyingParty());
 
@@ -246,12 +399,27 @@ public class AnalyticsLoginDataPublisherUtils {
      * Build authentication data object for authentication from event.
      * This method is for new stream definition V110.
      *
-     * @param event - triggerd event
+     * @param event  Event
      * @return AuthenticationData - authentication data object
      */
     public static AuthenticationData buildAuthnDataForAuthenticationV110(Event event) {
 
-        AuthenticationData authenticationData = buildAuthnDataForAuthentication(event);
+        return buildAuthnDataForAuthenticationV110(event, false);
+    }
+
+    /**
+     * Build authentication data object for authentication from event.
+     * This method is for new stream definition V110.
+     *
+     * @param event                      Event
+     * @param resolvePrimaryTenantDomain if {@code true}, SP and user tenant domains are resolved
+     *                                   to the primary organisation's org-handle before publishing.
+     * @return AuthenticationData - authentication data object
+     */
+    public static AuthenticationData buildAuthnDataForAuthenticationV110(Event event,
+                                                                         boolean resolvePrimaryTenantDomain) {
+
+        AuthenticationData authenticationData = buildAuthnDataForAuthentication(event, resolvePrimaryTenantDomain);
         Map<String, Object> properties = event.getEventProperties();
         AuthenticationContext context = (AuthenticationContext) properties.get(IdentityEventConstants.EventProperty.
                 CONTEXT);
@@ -264,27 +432,47 @@ public class AnalyticsLoginDataPublisherUtils {
     }
 
     private static void setTenantDataForAuthentication(AuthenticationContext context, AuthenticatorStatus status,
-                                                       AuthenticationData authenticationData) {
+                                                       AuthenticationData authenticationData,
+                                                       boolean resolvePrimaryTenantDomain) {
+
+        String spTenantDomain = context.getTenantDomain();
+        String userTenantDomain = authenticationData.getTenantDomain();
+
+        if (resolvePrimaryTenantDomain) {
+            // Resolve SP domain first; reuse the result for user domain when both are identical
+            // (most common case) to avoid a second call.
+            String resolvedSp = StringUtils.isNotBlank(spTenantDomain)
+                    ? getPrimaryOrgTenantDomain(spTenantDomain) : spTenantDomain;
+            String resolvedUser;
+            if (StringUtils.isNotBlank(userTenantDomain)) {
+                resolvedUser = userTenantDomain.equals(spTenantDomain)
+                        ? resolvedSp
+                        : getPrimaryOrgTenantDomain(userTenantDomain);
+            } else {
+                resolvedUser = userTenantDomain;
+            }
+            spTenantDomain = resolvedSp;
+            userTenantDomain = resolvedUser;
+
+        }
 
         if (status == AuthenticatorStatus.PASS) {
             authenticationData.addParameter(AnalyticsLoginDataPublishConstants.TENANT_DOMAIN_NAMES,
-                    AuthnDataPublisherUtils.getTenantDomains(context.getTenantDomain(), authenticationData.
-                            getTenantDomain()));
+                    AuthnDataPublisherUtils.getTenantDomains(spTenantDomain, userTenantDomain));
             authenticationData.addParameter(AuthPublisherConstants.SUBJECT_IDENTIFIER,
                     context.getSequenceConfig().getAuthenticatedUser().getAuthenticatedSubjectIdentifier());
             authenticationData.addParameter(AuthPublisherConstants.AUTHENTICATED_IDPS,
                     context.getSequenceConfig().getAuthenticatedIdPs());
         } else {
             // Should publish the event to both SP tenant domain and the tenant domain of the user who did the login
-            // attempt
-            if (context.getSequenceConfig() != null && context.getSequenceConfig().getApplicationConfig
-                    () != null && context.getSequenceConfig().getApplicationConfig().isSaaSApp()) {
+            // attempt.
+            if (context.getSequenceConfig() != null && context.getSequenceConfig().getApplicationConfig() != null
+                    && context.getSequenceConfig().getApplicationConfig().isSaaSApp()) {
                 authenticationData.addParameter(AnalyticsLoginDataPublishConstants.TENANT_DOMAIN_NAMES,
-                        AuthnDataPublisherUtils.getTenantDomains(context.getTenantDomain(), authenticationData.
-                                getTenantDomain()));
+                        AuthnDataPublisherUtils.getTenantDomains(spTenantDomain, userTenantDomain));
             } else {
                 authenticationData.addParameter(AnalyticsLoginDataPublishConstants.TENANT_DOMAIN_NAMES,
-                        AuthnDataPublisherUtils.getTenantDomains(context.getTenantDomain(), null));
+                        AuthnDataPublisherUtils.getTenantDomains(spTenantDomain, null));
             }
         }
     }
@@ -324,7 +512,8 @@ public class AnalyticsLoginDataPublisherUtils {
     }
 
     private static void setUserDataForAuthentication(AuthenticationData authenticationData,
-            Object userObj) {
+                                                     Object userObj, AuthenticationContext context,
+                                                     Map<String, Tenant> tenantCache) {
 
         if (userObj instanceof AuthenticatedUser) {
             AuthenticatedUser user = (AuthenticatedUser) userObj;
@@ -338,7 +527,24 @@ public class AnalyticsLoginDataPublisherUtils {
             }
             authenticationData.setTenantDomain(user.getTenantDomain());
             authenticationData.setUserStoreDomain(user.getUserStoreDomain());
+            updateUserOrgData(authenticationData, context, user, (User) userObj, tenantCache);
         }
+    }
+
+    private static void updateUserOrgData(AuthenticationData authenticationData, AuthenticationContext context,
+                                          AuthenticatedUser authenticatedUser, User user,
+                                          Map<String, Tenant> tenantCache) {
+
+        if (authenticatedUser != null && authenticatedUser.getUserResidentOrganization() != null) {
+            authenticationData.setUserResidingOrgId(authenticatedUser.getUserResidentOrganization());
+        } else {
+            if (ORGANIZATION_AUTHENTICATOR.equals(context.getCurrentAuthenticator())) {
+                authenticationData.setUserResidingOrgId((String) context.getProperty(ORG_ID));
+            } else {
+                authenticationData.setUserResidingOrgId(getOrgUuid(user.getTenantDomain(), tenantCache).orElse(null));
+            }
+        }
+        authenticationData.setUserLoginOrgId(getOrgUuid(user.getTenantDomain(), tenantCache).orElse(null));
     }
 
     private static AuthenticationData fillLocalEvent(AuthenticationData authenticationData,
@@ -432,5 +638,56 @@ public class AnalyticsLoginDataPublisherUtils {
             return (String) serializable;
         }
         return AuthPublisherConstants.NOT_AVAILABLE;
+    }
+
+    private static void updateSpResidingData(AuthenticationContext context, AuthenticationData authenticationData,
+                                             Map<String, Tenant> tenantCache) {
+
+        try {
+            ServiceProvider sp = AnalyticsLoginDataPublishDataHolder.getInstance()
+                    .getApplicationManagementService()
+                    .getServiceProvider(context.getServiceProviderName(), context.getTenantDomain());
+            if (sp == null || sp.getSpProperties() == null) {
+                return;
+            }
+            Optional<ServiceProviderProperty> fragmentAppProperty = Arrays.stream(sp.getSpProperties())
+                    .filter(s -> IS_FRAGMENT_APP.equals(s.getName()) && Boolean.parseBoolean(s.getValue()))
+                    .findAny();
+            String spResidingOrgId = null;
+
+            Tenant tenant = loadTenantByDomain(context.getTenantDomain(), tenantCache);
+            if (tenant != null) {
+                if (fragmentAppProperty.isPresent()) {
+                    spResidingOrgId = AnalyticsLoginDataPublishDataHolder.getInstance()
+                            .getOrganizationManager()
+                            .getPrimaryOrganizationId(tenant.getAssociatedOrganizationUUID());
+                } else {
+                    spResidingOrgId = tenant.getAssociatedOrganizationUUID();
+                }
+            }
+            authenticationData.setServiceProviderResidingOrgId(spResidingOrgId);
+        } catch (IdentityApplicationManagementException e) {
+            LOG.error("Error while retrieving service provider for " + context.getServiceProviderName()
+                    + " in tenant domain: " + context.getTenantDomain(), e);
+        } catch (OrganizationManagementServerException e) {
+            LOG.error("Error while retrieving primary organization ID for tenant: "
+                    + context.getTenantDomain(), e);
+        } catch (UserStoreException e) {
+            LOG.error("Error while retrieving tenant information for domain: "
+                    + context.getTenantDomain(), e);
+        }
+    }
+
+    private static Optional<String> getOrgUuid(String tenantDomain, Map<String, Tenant> tenantCache) {
+
+        try {
+            if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+                return Optional.of(OrganizationManagementConstants.SUPER_ORG_ID);
+            }
+            Tenant tenant = loadTenantByDomain(tenantDomain, tenantCache);
+            return Optional.ofNullable(tenant.getAssociatedOrganizationUUID());
+        } catch (UserStoreException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtils.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtils.java
@@ -18,11 +18,13 @@
 
 package org.wso2.carbon.identity.data.publisher.authentication.analytics.login;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorStatus;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
@@ -30,6 +32,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
 import org.wso2.carbon.identity.application.common.model.User;
@@ -45,6 +48,8 @@ import org.wso2.carbon.identity.organization.management.service.constant.Organiz
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
@@ -59,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -391,8 +397,96 @@ public class AnalyticsLoginDataPublisherUtils {
         updateSpResidingData(context, authenticationData, tenantCache);
 
         authenticationData.addParameter(AuthPublisherConstants.RELYING_PARTY, context.getRelyingParty());
+        setIdPAndAuthenticatorData(context, authenticationData);
 
         return authenticationData;
+    }
+
+    private static void setIdPAndAuthenticatorData(AuthenticationContext authContext,
+                                                          AuthenticationData authenticationData) {
+
+        Map<String, AuthenticatedIdPData> authenticatedIdPs = authContext.getCurrentAuthenticatedIdPs();
+        if (MapUtils.isEmpty(authenticatedIdPs)) {
+            return;
+        }
+        String serviceProvider = authContext.getServiceProviderName();
+        List<String> idpIdList = new ArrayList<>();
+        List authenticatorList = new ArrayList<>();
+        authenticatedIdPs.values().forEach(authenticatedIdPData -> {
+            addIdPResourceId(authenticatedIdPData, idpIdList, authContext.getTenantDomain(), serviceProvider);
+            authenticatorList.add(authenticatedIdPData.getAuthenticators().stream()
+                    .map(AuthenticatorConfig::getName).collect(Collectors.toList()));
+        });
+        List<String> flattenedAuthenticatorList = new ArrayList<>();
+        for (List<String> authenticators : (List<List<String>>) authenticatorList) {
+            for (Object authenticator : authenticators) {
+                flattenedAuthenticatorList.add(authenticator.toString().replaceAll("[\\[\\]]", ""));
+            }
+        }
+        if (!idpIdList.isEmpty()) {
+            authenticationData.setIdps(idpIdList);
+        }
+        if (!authenticatorList.isEmpty()) {
+            authenticationData.setAuthenticators(flattenedAuthenticatorList);
+        }
+    }
+
+    /**
+     * Set the IdP ID data to the Authentication IdP list.
+     * @param authenticatedIdPData  Authenticated IdP data.
+     * @param idpIdList             IdP ID list.
+     * @param tenantDomain          Tenant domain.
+     */
+    private static void addIdPResourceId(AuthenticatedIdPData authenticatedIdPData, List<String> idpIdList,
+                                  String tenantDomain, String serviceProvider) {
+
+        String key = authenticatedIdPData.getIdpName();
+        String resourceId = null;
+        if (authenticatedIdPData != null && authenticatedIdPData.getAuthenticators() != null &&
+                !authenticatedIdPData.getAuthenticators().isEmpty()) {
+            for (AuthenticatorConfig config : authenticatedIdPData.getAuthenticators()) {
+                if (config.getIdps().containsKey(key) && config.getIdps().get(key).getResourceId() != null) {
+                    resourceId = config.getIdps().get(key).getResourceId();
+                    break;
+                }
+            }
+        }
+        // If the resource ID is not found in the authenticator config, fetch from the database.
+        if (resourceId == null) {
+            resourceId = getIdPResourceIdByName(key, tenantDomain);
+        }
+        if (resourceId != null && !idpIdList.contains(resourceId)) {
+            idpIdList.add(resourceId);
+        }
+        if (resourceId == null) {
+            LOG.warn("Unable to resolve authenticated IdP resource Id for tenant: " + tenantDomain + " and IdP: " +
+                    key + " and service provider: " + serviceProvider);
+        }
+    }
+
+    /**
+     * Get the IdP ID by name.
+     *
+     * @param idpName       IdP name.
+     * @param tenantDomain  Tenant domain.
+     * @return IdP ID.
+     */
+    private static String getIdPResourceIdByName(String idpName, String tenantDomain) {
+
+        String resourceId = null;
+        try {
+            IdentityProvider identityProvider = IdentityProviderManager.getInstance().getIdPByName(idpName,
+                    tenantDomain);
+            if (identityProvider != null) {
+                resourceId = identityProvider.getResourceId();
+            }
+        } catch (IdentityProviderManagementException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while retrieving Identity Provider for name: " + idpName + " and tenant: " +
+                        tenantDomain, e);
+            }
+        }
+        return resourceId;
     }
 
     /**
@@ -535,11 +629,15 @@ public class AnalyticsLoginDataPublisherUtils {
                                           AuthenticatedUser authenticatedUser, User user,
                                           Map<String, Tenant> tenantCache) {
 
+        authenticationData.setOrganizationLogin(context.isOrgApplicationLogin());
+        authenticationData.setSharedAppLogin(context.isSharedAppLogin());
         if (authenticatedUser != null && authenticatedUser.getUserResidentOrganization() != null) {
             authenticationData.setUserResidingOrgId(authenticatedUser.getUserResidentOrganization());
         } else {
             if (ORGANIZATION_AUTHENTICATOR.equals(context.getCurrentAuthenticator())) {
                 authenticationData.setUserResidingOrgId((String) context.getProperty(ORG_ID));
+                // Legacy SSO login flow.
+                authenticationData.setSharedAppLogin(true);
             } else {
                 authenticationData.setUserResidingOrgId(getOrgUuid(user.getTenantDomain(), tenantCache).orElse(null));
             }
@@ -636,6 +734,14 @@ public class AnalyticsLoginDataPublisherUtils {
 
         if (serializable instanceof String) {
             return (String) serializable;
+        }
+        return AuthPublisherConstants.NOT_AVAILABLE;
+    }
+
+    public static Object replaceIfNotAvailable(Object object) {
+
+        if (object != null) {
+            return object;
         }
         return AuthPublisherConstants.NOT_AVAILABLE;
     }

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtils.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtils.java
@@ -115,7 +115,7 @@ public class AnalyticsLoginDataPublisherUtils {
                 AUTHENTICATION_STATUS);
 
         // Tenant cache: avoids redundant DB lookups for the same domain within this call.
-        Map<String, Tenant> tenantCache = new HashMap<>();
+        Map<String, Tenant> tenantMap = new HashMap<>();
 
         AuthenticationData authenticationData = new AuthenticationData();
         setIdpForAuthnStep(context, authenticationData);
@@ -123,7 +123,7 @@ public class AnalyticsLoginDataPublisherUtils {
         boolean isInvalidUsername =
                 context.getProperty(IS_INVALID_USERNAME) != null && (boolean) context.getProperty(IS_INVALID_USERNAME);
         context.setProperty(IS_INVALID_USERNAME, null);
-        setUserDataForAuthnStep(authenticationData, userObj, isInvalidUsername, context, tenantCache);
+        setUserDataForAuthnStep(authenticationData, userObj, isInvalidUsername, context, tenantMap);
 
         Object isFederatedObj = params.get(FrameworkConstants.AnalyticsAttributes.IS_FEDERATED);
         setIdpTypeForAuthnStep(authenticationData, isFederatedObj);
@@ -148,7 +148,7 @@ public class AnalyticsLoginDataPublisherUtils {
         authenticationData.setStepNo(context.getCurrentStep());
         authenticationData.setUsernameUserInput((String) context.getProperty(USERNAME_USER_INPUT));
         setTenantDataForIdpStep(context, status, authenticationData, resolvePrimaryTenantDomain);
-        updateSpResidingData(context, authenticationData, tenantCache);
+        updateSpResidingData(context, authenticationData, tenantMap);
 
         authenticationData.addParameter(AuthPublisherConstants.RELYING_PARTY, context.getRelyingParty());
         return authenticationData;
@@ -252,19 +252,19 @@ public class AnalyticsLoginDataPublisherUtils {
     }
 
     /**
-     * Loads a {@link Tenant} by domain, consulting {@code tenantCache} first so the same tenant
+     * Loads a {@link Tenant} by domain, consulting {@code tenantMap} first so the same tenant
      * is never fetched more than once per request.
      */
-    private static Tenant loadTenantByDomain(String domain, Map<String, Tenant> tenantCache)
+    private static Tenant loadTenantByDomain(String domain, Map<String, Tenant> tenantMap)
             throws UserStoreException {
 
-        if (tenantCache.containsKey(domain)) {
-            return tenantCache.get(domain);
+        if (tenantMap.containsKey(domain)) {
+            return tenantMap.get(domain);
         }
         Tenant tenant = AnalyticsLoginDataPublishDataHolder.getInstance()
                 .getRealmService().getTenantManager().getTenantByDomain(domain);
         // Cache even a null result so we don't hit the DB again for the same domain.
-        tenantCache.put(domain, tenant);
+        tenantMap.put(domain, tenant);
         return tenant;
     }
 
@@ -283,7 +283,7 @@ public class AnalyticsLoginDataPublisherUtils {
 
     private static void setUserDataForAuthnStep(AuthenticationData authenticationData, Object userObj,
                                                 boolean isInvalidUsername, AuthenticationContext context,
-                                                Map<String, Tenant> tenantCache) {
+                                                Map<String, Tenant> tenantMap) {
 
         if (userObj instanceof User) {
             User user = (User) userObj;
@@ -305,7 +305,7 @@ public class AnalyticsLoginDataPublisherUtils {
                     LOG.debug("Null user id is found in the AuthenticatedUser instance.");
                 }
             }
-            updateUserOrgData(authenticationData, context, user, (User) userObj, tenantCache);
+            updateUserOrgData(authenticationData, context, user, (User) userObj, tenantMap);
         } else {
             try {
                 // Resolve userId and organization data for unauthenticated users.
@@ -318,7 +318,7 @@ public class AnalyticsLoginDataPublisherUtils {
                     org.wso2.carbon.user.core.common.User user1 = userStoreManager.getUser(null,
                             UserCoreUtil.addDomainToName(user.getUserName(), user.getUserStoreDomain()));
                     authenticationData.setUserId(user1.getUserID());
-                    updateUserOrgData(authenticationData, context, null, (User) userObj, tenantCache);
+                    updateUserOrgData(authenticationData, context, null, (User) userObj, tenantMap);
                 }
             } catch (UserStoreException e) {
                 throw new RuntimeException(e);
@@ -366,11 +366,11 @@ public class AnalyticsLoginDataPublisherUtils {
                 AUTHENTICATION_STATUS);
 
         // Tenant cache: avoids redundant DB lookups for the same domain within this call.
-        Map<String, Tenant> tenantCache = new HashMap<>();
+        Map<String, Tenant> tenantMap = new HashMap<>();
 
         AuthenticationData authenticationData = new AuthenticationData();
         Object userObj = params.get(FrameworkConstants.AnalyticsAttributes.USER);
-        setUserDataForAuthentication(authenticationData, userObj, context, tenantCache);
+        setUserDataForAuthentication(authenticationData, userObj, context, tenantMap);
 
         authenticationData = setIdpDataAndStepForAuthentication(context, status, authenticationData);
 
@@ -394,7 +394,7 @@ public class AnalyticsLoginDataPublisherUtils {
         authenticationData.setPassive(context.isPassiveAuthenticate());
         authenticationData.setUsernameUserInput((String) context.getProperty(USERNAME_USER_INPUT));
         setTenantDataForAuthentication(context, status, authenticationData, resolvePrimaryTenantDomain);
-        updateSpResidingData(context, authenticationData, tenantCache);
+        updateSpResidingData(context, authenticationData, tenantMap);
 
         authenticationData.addParameter(AuthPublisherConstants.RELYING_PARTY, context.getRelyingParty());
         setIdPAndAuthenticatorData(context, authenticationData);
@@ -607,7 +607,7 @@ public class AnalyticsLoginDataPublisherUtils {
 
     private static void setUserDataForAuthentication(AuthenticationData authenticationData,
                                                      Object userObj, AuthenticationContext context,
-                                                     Map<String, Tenant> tenantCache) {
+                                                     Map<String, Tenant> tenantMap) {
 
         if (userObj instanceof AuthenticatedUser) {
             AuthenticatedUser user = (AuthenticatedUser) userObj;
@@ -621,13 +621,13 @@ public class AnalyticsLoginDataPublisherUtils {
             }
             authenticationData.setTenantDomain(user.getTenantDomain());
             authenticationData.setUserStoreDomain(user.getUserStoreDomain());
-            updateUserOrgData(authenticationData, context, user, (User) userObj, tenantCache);
+            updateUserOrgData(authenticationData, context, user, (User) userObj, tenantMap);
         }
     }
 
     private static void updateUserOrgData(AuthenticationData authenticationData, AuthenticationContext context,
                                           AuthenticatedUser authenticatedUser, User user,
-                                          Map<String, Tenant> tenantCache) {
+                                          Map<String, Tenant> tenantMap) {
 
         authenticationData.setOrganizationLogin(context.isOrgApplicationLogin());
         authenticationData.setSharedAppLogin(context.isSharedAppLogin());
@@ -639,10 +639,10 @@ public class AnalyticsLoginDataPublisherUtils {
                 // Legacy SSO login flow.
                 authenticationData.setSharedAppLogin(true);
             } else {
-                authenticationData.setUserResidingOrgId(getOrgUuid(user.getTenantDomain(), tenantCache).orElse(null));
+                authenticationData.setUserResidingOrgId(getOrgUuid(user.getTenantDomain(), tenantMap).orElse(null));
             }
         }
-        authenticationData.setUserLoginOrgId(getOrgUuid(user.getTenantDomain(), tenantCache).orElse(null));
+        authenticationData.setUserLoginOrgId(getOrgUuid(user.getTenantDomain(), tenantMap).orElse(null));
     }
 
     private static AuthenticationData fillLocalEvent(AuthenticationData authenticationData,
@@ -747,7 +747,7 @@ public class AnalyticsLoginDataPublisherUtils {
     }
 
     private static void updateSpResidingData(AuthenticationContext context, AuthenticationData authenticationData,
-                                             Map<String, Tenant> tenantCache) {
+                                             Map<String, Tenant> tenantMap) {
 
         try {
             ServiceProvider sp = AnalyticsLoginDataPublishDataHolder.getInstance()
@@ -761,7 +761,7 @@ public class AnalyticsLoginDataPublisherUtils {
                     .findAny();
             String spResidingOrgId = null;
 
-            Tenant tenant = loadTenantByDomain(context.getTenantDomain(), tenantCache);
+            Tenant tenant = loadTenantByDomain(context.getTenantDomain(), tenantMap);
             if (tenant != null) {
                 if (fragmentAppProperty.isPresent()) {
                     spResidingOrgId = AnalyticsLoginDataPublishDataHolder.getInstance()
@@ -784,13 +784,13 @@ public class AnalyticsLoginDataPublisherUtils {
         }
     }
 
-    private static Optional<String> getOrgUuid(String tenantDomain, Map<String, Tenant> tenantCache) {
+    private static Optional<String> getOrgUuid(String tenantDomain, Map<String, Tenant> tenantMap) {
 
         try {
             if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
                 return Optional.of(OrganizationManagementConstants.SUPER_ORG_ID);
             }
-            Tenant tenant = loadTenantByDomain(tenantDomain, tenantCache);
+            Tenant tenant = loadTenantByDomain(tenantDomain, tenantMap);
             return Optional.ofNullable(tenant.getAssociatedOrganizationUUID());
         } catch (UserStoreException e) {
             return Optional.empty();

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/internal/AnalyticsLoginDataPublishDataHolder.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/internal/AnalyticsLoginDataPublishDataHolder.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.identity.data.publisher.authentication.analytics.login.internal;
 
 import org.wso2.carbon.event.stream.core.EventStreamService;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
 public class AnalyticsLoginDataPublishDataHolder {
@@ -27,6 +29,8 @@ public class AnalyticsLoginDataPublishDataHolder {
             = new AnalyticsLoginDataPublishDataHolder();
     private EventStreamService publisherService;
     private RealmService realmService;
+    private ApplicationManagementService applicationManagementService;
+    private OrganizationManager organizationManager;
 
     private AnalyticsLoginDataPublishDataHolder() {
 
@@ -57,4 +61,19 @@ public class AnalyticsLoginDataPublishDataHolder {
         this.realmService = realmService;
     }
 
+    public ApplicationManagementService getApplicationManagementService() {
+        return applicationManagementService;
+    }
+
+    public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+        this.applicationManagementService = applicationManagementService;
+    }
+
+    public OrganizationManager getOrganizationManager() {
+        return organizationManager;
+    }
+
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+        this.organizationManager = organizationManager;
+    }
 }

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/internal/AnalyticsLoginDataPublishDataHolder.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/internal/AnalyticsLoginDataPublishDataHolder.java
@@ -62,18 +62,22 @@ public class AnalyticsLoginDataPublishDataHolder {
     }
 
     public ApplicationManagementService getApplicationManagementService() {
+
         return applicationManagementService;
     }
 
     public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
         this.applicationManagementService = applicationManagementService;
     }
 
     public OrganizationManager getOrganizationManager() {
+
         return organizationManager;
     }
 
     public void setOrganizationManager(OrganizationManager organizationManager) {
+
         this.organizationManager = organizationManager;
     }
 }

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/internal/AnalyticsLoginDataPublishServiceComponent.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/internal/AnalyticsLoginDataPublishServiceComponent.java
@@ -29,10 +29,12 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.event.stream.core.EventStreamService;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.data.publisher.authentication.analytics.login.AnalyticsB2BLoginDataPublishHandler;
 import org.wso2.carbon.identity.data.publisher.authentication.analytics.login.AnalyticsLoginDataPublishHandler;
 import org.wso2.carbon.identity.data.publisher.authentication.analytics.login.AnalyticsLoginDataPublishHandlerV110;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -121,6 +123,38 @@ public class AnalyticsLoginDataPublishServiceComponent {
             log.debug("Un-setting the Event Stream Service");
         }
         AnalyticsLoginDataPublishDataHolder.getInstance().setPublisherService(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.application.mgt.ApplicationManagementService",
+            service = ApplicationManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetApplicationManagementService"
+    )
+    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        AnalyticsLoginDataPublishDataHolder.getInstance().setApplicationManagementService(applicationManagementService);
+    }
+
+    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        AnalyticsLoginDataPublishDataHolder.getInstance().setApplicationManagementService(null);
+    }
+
+    @Reference(name = "identity.organization.management.component",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager")
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        AnalyticsLoginDataPublishDataHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        AnalyticsLoginDataPublishDataHolder.getInstance().setOrganizationManager(null);
     }
 
 }

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/model/AuthenticationData.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/model/AuthenticationData.java
@@ -56,6 +56,9 @@ public class AuthenticationData<T1 extends Object, T2 extends Object> {
     private String errorCode;
     private List<String> customParams;
     private String usernameUserInput;
+    private String serviceProviderResidingOrgId;
+    private String userResidingOrgId;
+    private String userLoginOrgId;
 
     public String getEventId() {
 
@@ -335,5 +338,29 @@ public class AuthenticationData<T1 extends Object, T2 extends Object> {
     public void setUsernameUserInput(String usernameUserInput) {
 
         this.usernameUserInput = usernameUserInput;
+    }
+
+    public String getServiceProviderResidingOrgId() {
+        return serviceProviderResidingOrgId;
+    }
+
+    public void setServiceProviderResidingOrgId(String serviceProviderResidingOrgId) {
+        this.serviceProviderResidingOrgId = serviceProviderResidingOrgId;
+    }
+
+    public String getUserResidingOrgId() {
+        return userResidingOrgId;
+    }
+
+    public void setUserResidingOrgId(String userResidingOrgId) {
+        this.userResidingOrgId = userResidingOrgId;
+    }
+
+    public String getUserLoginOrgId() {
+        return userLoginOrgId;
+    }
+
+    public void setUserLoginOrgId(String userLoginOrgId) {
+        this.userLoginOrgId = userLoginOrgId;
     }
 }

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/model/AuthenticationData.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/model/AuthenticationData.java
@@ -59,6 +59,10 @@ public class AuthenticationData<T1 extends Object, T2 extends Object> {
     private String serviceProviderResidingOrgId;
     private String userResidingOrgId;
     private String userLoginOrgId;
+    private boolean isOrganizationLogin;
+    private boolean isSharedAppLogin;
+    private List<String> authenticators;
+    private List<String> idps;
 
     public String getEventId() {
 
@@ -362,5 +366,37 @@ public class AuthenticationData<T1 extends Object, T2 extends Object> {
 
     public void setUserLoginOrgId(String userLoginOrgId) {
         this.userLoginOrgId = userLoginOrgId;
+    }
+
+    public boolean isOrganizationLogin() {
+        return isOrganizationLogin;
+    }
+
+    public void setOrganizationLogin(boolean organizationLogin) {
+        isOrganizationLogin = organizationLogin;
+    }
+
+    public boolean isSharedAppLogin() {
+        return isSharedAppLogin;
+    }
+
+    public void setSharedAppLogin(boolean sharedAppLogin) {
+        isSharedAppLogin = sharedAppLogin;
+    }
+
+    public List<String> getAuthenticators() {
+        return authenticators;
+    }
+
+    public void setAuthenticators(List<String> authenticators) {
+        this.authenticators = authenticators;
+    }
+
+    public List<String> getIdps() {
+        return idps;
+    }
+
+    public void setIdps(List<String> idps) {
+        this.idps = idps;
     }
 }

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/test/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtilsTest.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/test/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublisherUtilsTest.java
@@ -19,41 +19,80 @@
 package org.wso2.carbon.identity.data.publisher.authentication.analytics.login;
 
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
 
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.data.publisher.authentication.analytics.login.internal.AnalyticsLoginDataPublishDataHolder;
 import org.wso2.carbon.identity.data.publisher.authentication.analytics.login.model.AuthenticationData;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.user.api.Tenant;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.tenant.TenantManager;
 
 import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 public class AnalyticsLoginDataPublisherUtilsTest {
 
+    private AutoCloseable mocks;
+
     private static final String TENANT_DOMAIN = "abc.com";
+    private static final String ORG_UUID = "test-org-uuid";
+
     @Mock
     HttpServletRequest mockHttpServletRequest;
     @Mock
     AuthenticationContext mockAuthenticationContext;
     @Mock
     SessionContext mockSessionContext;
+    @Mock
+    RealmService mockRealmService;
+    @Mock
+    TenantManager mockTenantManager;
+    @Mock
+    Tenant mockTenant;
+    @Mock
+    ApplicationManagementService mockApplicationManagementService;
 
     @BeforeTest
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
+    public void setUp() throws Exception {
+
+        mocks = MockitoAnnotations.openMocks(this);
+
         when(mockAuthenticationContext.getExternalIdP()).thenReturn(null);
+
+        Mockito.doReturn(mockTenantManager).when(mockRealmService).getTenantManager();
+        when(mockTenantManager.getTenantByDomain(eq(TENANT_DOMAIN))).thenReturn(mockTenant);
+        when(mockTenantManager.getTenantByDomain(eq(null))).thenReturn(null);
+        when(mockTenant.getAssociatedOrganizationUUID()).thenReturn(ORG_UUID);
+
+        when(mockApplicationManagementService.getServiceProvider(any(), any())).thenReturn(null);
+
+        AnalyticsLoginDataPublishDataHolder.getInstance().setRealmService(mockRealmService);
+        AnalyticsLoginDataPublishDataHolder.getInstance()
+                .setApplicationManagementService(mockApplicationManagementService);
+    }
+
+    @AfterClass
+    public void tearDown() throws Exception {
+
+        mocks.close();
     }
 
     @DataProvider(name = "getEvent")

--- a/features/org.wso2.carbon.identity.data.publisher.application.authentication.server.feature/resources/org.wso2.is.analytics.stream.OverallAuthentication_1.1.0.json
+++ b/features/org.wso2.carbon.identity.data.publisher.application.authentication.server.feature/resources/org.wso2.is.analytics.stream.OverallAuthentication_1.1.0.json
@@ -115,6 +115,18 @@
       "type": "STRING"
     },
     {
+      "name": "userLoginOrgId",
+      "type": "STRING"
+    },
+    {
+      "name": "userResidingOrgId",
+      "type": "STRING"
+    },
+    {
+      "name": "spResidingOrgId",
+      "type": "STRING"
+    },
+    {
       "name": "customParam1",
       "type": "STRING"
     },

--- a/features/org.wso2.carbon.identity.data.publisher.application.authentication.server.feature/resources/org.wso2.is.analytics.stream.OverallAuthentication_1.1.0.json
+++ b/features/org.wso2.carbon.identity.data.publisher.application.authentication.server.feature/resources/org.wso2.is.analytics.stream.OverallAuthentication_1.1.0.json
@@ -127,6 +127,22 @@
       "type": "STRING"
     },
     {
+      "name": "isOrganizationLogin",
+      "type": "BOOL"
+    },
+    {
+      "name": "isSharedAppLogin",
+      "type": "BOOL"
+    },
+    {
+      "name": "idps",
+      "type": "ARRAY"
+    },
+    {
+      "name": "authenticators",
+      "type": "ARRAY"
+    },
+    {
       "name": "customParam1",
       "type": "STRING"
     },

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,16 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.user.api</artifactId>
+                <version>${carbon.kernel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.flow.execution.engine</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.core</artifactId>
                 <version>${carbon.identity.framework.version}</version>
@@ -64,6 +74,16 @@
             <dependency>
                 <groupId>org.wso2.carbon.analytics-common</groupId>
                 <artifactId>org.wso2.carbon.event.stream.core</artifactId>
+                <version>${carbon.analytics-common.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.analytics-common</groupId>
+                <artifactId>org.wso2.carbon.event.output.adapter.http</artifactId>
+                <version>${carbon.analytics-common.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.analytics-common</groupId>
+                <artifactId>org.wso2.carbon.event.output.adapter.core</artifactId>
                 <version>${carbon.analytics-common.version}</version>
             </dependency>
             <dependency>
@@ -86,6 +106,11 @@
                 <artifactId>org.wso2.carbon.identity.data.publisher.application.authentication</artifactId>
                 <version>${project.version}</version>
                 <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.datapublisher.authentication</groupId>
+                <artifactId>org.wso2.carbon.identity.data.publisher.authentication.analytics.login</artifactId>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
@@ -118,6 +143,21 @@
                 <version>${pax.logging.api.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.secret.mgt.core</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.tenant.resource.manager</artifactId>
+                <version>${identity.governance.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.api.version}</version>
@@ -138,6 +178,27 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${identity.organization.management.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.recovery</artifactId>
+                <version>${identity.governance.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.wso2.carbon.commons</groupId>
+                        <artifactId>org.wso2.carbon.ntask.core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.governance</artifactId>
+                <version>${identity.governance.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -291,21 +352,26 @@
         <module>features/org.wso2.carbon.identity.data.publisher.application.authentication.server.feature</module>
     </modules>
     <properties>
-        <carbon.kernel.version>4.5.0</carbon.kernel.version>
+        <carbon.kernel.version>4.12.1</carbon.kernel.version>
         <carbon.kernel.feature.version>4.5.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.version>7.10.9</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.30</carbon.identity.framework.version>
         <carbon.identity.data.publisher.package.export.version>${project.version}</carbon.identity.data.publisher.package.export.version>
         <carbon.identity.data.publisher.package.import.version.range>[5.3.0, 6.0.0)</carbon.identity.data.publisher.package.import.version.range>
         <carbon.identity.framework.package.import.version.range>[5.14.67, 8.0.0)</carbon.identity.framework.package.import.version.range>
-        <carbon.analytics-common.version>5.2.50</carbon.analytics-common.version>
+        <carbon.analytics-common.version>5.5.2</carbon.analytics-common.version>
+        <identity.governance.version>1.11.21</identity.governance.version>
         <carbon.analytics-common.imp.pkg.version.range>[5.2.10,6.0.0)</carbon.analytics-common.imp.pkg.version.range>
+        <identity.organization.management.core.version>1.5.2</identity.organization.management.core.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
 
+        <identity.governance.imp.pkg.version.range>[1.0.0, 3.0.0)</identity.governance.imp.pkg.version.range>
+        <identity.organization.management.core.imp.pkg.version.range>[1.0.0,3.0.0)
+        </identity.organization.management.core.imp.pkg.version.range>
         <!-- Unit test versions -->
         <mockito.version>5.3.1</mockito.version>
         <testng.version>7.10.1</testng.version>
@@ -324,7 +390,7 @@
         <pax.logging.api.version>2.1.0-wso2v4</pax.logging.api.version>
         <slf4j.api.version>1.6.1</slf4j.api.version>
         <org.slf4j.imp.pkg.version.range>[1.5.5,2.0.0)</org.slf4j.imp.pkg.version.range>
-    
+        <commons-collections.wso2.osgi.version.range>[3.2.0,4.0.0)</commons-collections.wso2.osgi.version.range>
         <jacoco.version>0.8.12</jacoco.version>
     </properties>
 


### PR DESCRIPTION
This pull request enhances the authentication analytics login data publisher to support organization-aware login analytics. The main changes include updating the payload structure, introducing organization-related fields, refactoring utility methods to support organization resolution, and updating dependencies to support these features.

**Support for Organization-Aware Analytics:**

* Added new fields (`userLoginOrgId`, `userResidingOrgId`, and `serviceProviderResidingOrgId`) to the analytics payload and increased the payload length to accommodate these fields. [[1]](diffhunk://#diff-34639bca8bd1b523c5159446c4497500b980b4b363fa5f6faae3d8103b772ad7L51-R52) [[2]](diffhunk://#diff-34639bca8bd1b523c5159446c4497500b980b4b363fa5f6faae3d8103b772ad7L147-R156)
* Updated the logic in `AnalyticsLoginDataPublisherUtils` to resolve and populate organization-related information for both users and service providers, including methods for resolving primary organization tenant domains and caching tenant lookups. [[1]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2R85-R97) [[2]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2R106-R115) [[3]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2L107-R140) [[4]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2L122-R169) [[5]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2L135-R257)

**Refactoring and API Improvements:**

* Refactored utility methods to support an optional parameter for resolving primary tenant domains, and updated method signatures and internal logic accordingly. [[1]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2R85-R97) [[2]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2L122-R169) [[3]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2L135-R257)
* Improved construction of user role names by using `UserCoreUtil.addDomainToName` for consistency and correctness.

**Dependency and Import Updates:**

* Added new Maven dependencies for organization management and user API modules in `pom.xml`. [[1]](diffhunk://#diff-46cf1b25f7b709f856466a688568a35b2cc3ac5f8a764c66e0abe9729418b939R41-R44) [[2]](diffhunk://#diff-46cf1b25f7b709f856466a688568a35b2cc3ac5f8a764c66e0abe9729418b939R88-R91)
* Updated OSGi import packages to include organization management and application management packages. [[1]](diffhunk://#diff-46cf1b25f7b709f856466a688568a35b2cc3ac5f8a764c66e0abe9729418b939R126) [[2]](diffhunk://#diff-46cf1b25f7b709f856466a688568a35b2cc3ac5f8a764c66e0abe9729418b939R138-R140)

**Code Maintenance:**

* Added new constants and improved imports for clarity and maintainability. [[1]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2R24-R55) [[2]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2R72-R75)

These changes collectively enable the analytics login data publisher to support multi-organization scenarios and improve the accuracy and richness of login analytics data.

**References:**  
[[1]](diffhunk://#diff-34639bca8bd1b523c5159446c4497500b980b4b363fa5f6faae3d8103b772ad7L51-R52) [[2]](diffhunk://#diff-34639bca8bd1b523c5159446c4497500b980b4b363fa5f6faae3d8103b772ad7L147-R156) [[3]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2R85-R97) [[4]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2R106-R115) [[5]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2L107-R140) [[6]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2L122-R169) [[7]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2L135-R257) [[8]](diffhunk://#diff-34639bca8bd1b523c5159446c4497500b980b4b363fa5f6faae3d8103b772ad7L99-R104) [[9]](diffhunk://#diff-46cf1b25f7b709f856466a688568a35b2cc3ac5f8a764c66e0abe9729418b939R41-R44) [[10]](diffhunk://#diff-46cf1b25f7b709f856466a688568a35b2cc3ac5f8a764c66e0abe9729418b939R88-R91) [[11]](diffhunk://#diff-46cf1b25f7b709f856466a688568a35b2cc3ac5f8a764c66e0abe9729418b939R126) [[12]](diffhunk://#diff-46cf1b25f7b709f856466a688568a35b2cc3ac5f8a764c66e0abe9729418b939R138-R140) [[13]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2R24-R55) [[14]](diffhunk://#diff-d4b644b37c3b9d015bf16737128b77c17bae53eb53950c2d5ff57cd3f93695d2R72-R75)