### PR TITLE
Publish user groups in the login analytics event

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/pom.xml
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/pom.xml
@@ -139,8 +139,7 @@
                             org.wso2.carbon.identity.organization.management.*; version="${identity.organization.management.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.common.*; version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
-                            org.wso2.carbon.utils.multitenancy; version="${carbon.kernel.package.import.version.range}"
+                            org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.data.publisher.authentication.analytics.login.internal,

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/pom.xml
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/pom.xml
@@ -139,7 +139,8 @@
                             org.wso2.carbon.identity.organization.management.*; version="${identity.organization.management.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.common.*; version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}"
+                            org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
+                            org.wso2.carbon.utils.multitenancy; version="${carbon.kernel.package.import.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.data.publisher.authentication.analytics.login.internal,

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublishHandlerV110.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublishHandlerV110.java
@@ -38,10 +38,14 @@ import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 /**
  * Publish authentication login data to analytics server.
@@ -50,7 +54,7 @@ import java.util.UUID;
 public class AnalyticsLoginDataPublishHandlerV110 extends AbstractEventHandler {
 
     private static final Log LOG = LogFactory.getLog(AnalyticsLoginDataPublishHandlerV110.class);
-    private static final int PAYLOAD_LENGTH = 38;
+    private static final int PAYLOAD_LENGTH = 39;
 
     @Override
     public String getName() {
@@ -97,12 +101,17 @@ public class AnalyticsLoginDataPublishHandlerV110 extends AbstractEventHandler {
     protected Object[] populatePayloadData(AuthenticationData authenticationData, boolean useISOTimestamp) {
 
         String roleList = null;
+        List<String> groupList = new ArrayList<>();
         if (FrameworkConstants.LOCAL_IDP_NAME.equalsIgnoreCase(authenticationData.getIdentityProviderType())) {
-            roleList = getCommaSeparatedUserRoles(UserCoreUtil.addDomainToName(authenticationData.getUsername(),
-                    authenticationData.getUserStoreDomain()), authenticationData.getTenantDomain());
+            String domainQualifiedUsername = UserCoreUtil.addDomainToName(authenticationData.getUsername(),
+                    authenticationData.getUserStoreDomain());
+            roleList = getCommaSeparatedUserRoles(domainQualifiedUsername, authenticationData.getTenantDomain());
+            groupList = getUserGroups(domainQualifiedUsername, authenticationData.getTenantDomain());
         } else if (StringUtils.isNotEmpty(authenticationData.getLocalUsername())) {
-            roleList = getCommaSeparatedUserRoles(UserCoreUtil.addDomainToName(authenticationData.getLocalUsername(),
-                    authenticationData.getUserStoreDomain()), authenticationData.getTenantDomain());
+            String domainQualifiedUsername = UserCoreUtil.addDomainToName(authenticationData.getLocalUsername(),
+                    authenticationData.getUserStoreDomain());
+            roleList = getCommaSeparatedUserRoles(domainQualifiedUsername, authenticationData.getTenantDomain());
+            groupList = getUserGroups(domainQualifiedUsername, authenticationData.getTenantDomain());
         }
 
         Object[] payloadData = new Object[PAYLOAD_LENGTH];
@@ -157,9 +166,11 @@ public class AnalyticsLoginDataPublishHandlerV110 extends AbstractEventHandler {
 
         payloadData[31] = AnalyticsLoginDataPublisherUtils.replaceIfNotAvailable(authenticationData.getIdentityProviders());
         payloadData[32] = AnalyticsLoginDataPublisherUtils.replaceIfStringNotAvailable(authenticationData.getAuthenticator());
+        // Publish groups as an array (a single group is still emitted as a one element array).
+        payloadData[33] = groupList;
         List<String> customParams = authenticationData.getCustomParams();
         for (int i = 0; i < customParams.size(); i++) {
-            payloadData[33 + i] = customParams.get(i);
+            payloadData[34 + i] = customParams.get(i);
         }
 
         if (LOG.isDebugEnabled()) {
@@ -253,6 +264,49 @@ public class AnalyticsLoginDataPublishHandlerV110 extends AbstractEventHandler {
             LOG.debug("No roles found. Returning empty string");
         }
         return StringUtils.EMPTY;
+    }
+
+    private List<String> getUserGroups(String userName, String tenantDomain) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Retrieving groups for user " + userName + ", tenant domain " + tenantDomain);
+        }
+        userName = MultitenantUtils.getTenantAwareUsername(userName);
+        List<String> groups = new ArrayList<>();
+        if (tenantDomain == null || userName == null) {
+            return groups;
+        }
+
+        RealmService realmService = AnalyticsLoginDataPublishDataHolder.getInstance().getRealmService();
+
+        try {
+            int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
+            UserRealm realm = (UserRealm) realmService.getTenantUserRealm(tenantId);
+            if (realm == null) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("No realm found for tenant domain : " + tenantDomain + ". Hence no groups added");
+                }
+                return groups;
+            }
+            UserStoreManager userstore = realm.getUserStoreManager();
+            if (!userstore.isExistingUser(userName)) {
+                return groups;
+            }
+            // Read groups via the groups claim URI. The user store's getGroupListOfUser/role APIs return
+            // roles, so the claim value is the reliable source for the user's groups.
+            String groupClaimValue = userstore.getUserClaimValue(userName, FrameworkConstants.GROUPS_CLAIM, null);
+            if (StringUtils.isBlank(groupClaimValue)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("No groups found. Returning empty list");
+                }
+                return groups;
+            }
+            // Multi-valued claims are joined by the user store's multi attribute separator.
+            groups.addAll(Arrays.asList(groupClaimValue.split(Pattern.quote(FrameworkUtils.getMultiAttributeSeparator()))));
+        } catch (UserStoreException e) {
+            LOG.error("Error when getting groups for " + userName + "@" + tenantDomain, e);
+        }
+        return groups;
     }
 
     private boolean isAnalyticsLoginDataPublishingEnabled(Event event) throws IdentityEventException {

--- a/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublishHandlerV110.java
+++ b/components/org.wso2.carbon.identity.data.publisher.authentication.analytics.login/src/main/java/org/wso2/carbon/identity/data/publisher/authentication/analytics/login/AnalyticsLoginDataPublishHandlerV110.java
@@ -38,7 +38,6 @@ import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
-import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -271,7 +270,6 @@ public class AnalyticsLoginDataPublishHandlerV110 extends AbstractEventHandler {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Retrieving groups for user " + userName + ", tenant domain " + tenantDomain);
         }
-        userName = MultitenantUtils.getTenantAwareUsername(userName);
         List<String> groups = new ArrayList<>();
         if (tenantDomain == null || userName == null) {
             return groups;
@@ -302,7 +300,8 @@ public class AnalyticsLoginDataPublishHandlerV110 extends AbstractEventHandler {
                 return groups;
             }
             // Multi-valued claims are joined by the user store's multi attribute separator.
-            groups.addAll(Arrays.asList(groupClaimValue.split(Pattern.quote(FrameworkUtils.getMultiAttributeSeparator()))));
+            groups.addAll(Arrays.asList(groupClaimValue.split(
+                    Pattern.quote(FrameworkUtils.getMultiAttributeSeparator()))));
         } catch (UserStoreException e) {
             LOG.error("Error when getting groups for " + userName + "@" + tenantDomain, e);
         }

--- a/features/org.wso2.carbon.identity.data.publisher.application.authentication.server.feature/resources/org.wso2.is.analytics.stream.OverallAuthentication_1.1.0.json
+++ b/features/org.wso2.carbon.identity.data.publisher.application.authentication.server.feature/resources/org.wso2.is.analytics.stream.OverallAuthentication_1.1.0.json
@@ -147,10 +147,6 @@
       "type": "ARRAY"
     },
     {
-      "name": "isoTimestamp",
-      "type": "STRING"
-    },
-    {
       "name": "customParam1",
       "type": "STRING"
     },

--- a/features/org.wso2.carbon.identity.data.publisher.application.authentication.server.feature/resources/org.wso2.is.analytics.stream.OverallAuthentication_1.1.0.json
+++ b/features/org.wso2.carbon.identity.data.publisher.application.authentication.server.feature/resources/org.wso2.is.analytics.stream.OverallAuthentication_1.1.0.json
@@ -143,6 +143,10 @@
       "type": "ARRAY"
     },
     {
+      "name": "groups",
+      "type": "ARRAY"
+    },
+    {
       "name": "isoTimestamp",
       "type": "STRING"
     },


### PR DESCRIPTION
## Summary
Adds the user's **groups** to the login-flow analytics event, alongside the existing roles, for the Moesif identity integration.

## Changes
- `AnalyticsLoginDataPublishHandlerV110`: new `getCommaSeparatedUserGroups(userId, tenantDomain)` that fetches groups from the user store via `AbstractUserStoreManager.getGroupListOfUser(...)`, filtered the same way as roles (internal/application/workflow domains dropped, domain prefix stripped). The new value is written to a new `groupsCommaSeparated` payload field (index 33, before the `customParam*` fields); `PAYLOAD_LENGTH` 38 → 39.
- `org.wso2.is.analytics.stream.OverallAuthentication_1.1.0.json`: declare the new `groupsCommaSeparated` field.

## Notes
- **No combined roles+groups call exists** in the user store API, so groups are fetched separately (mirroring roles), per design discussion.
- Groups are keyed by **user id**, which is already resolved on `AuthenticationData` — reused directly to avoid a second id resolution. When it isn't available (e.g. federated login without a local user), the field is set to `NOT_AVAILABLE`.
- Paired with wso2-extensions/identity-moesif-integration (adds the same field to the Moesif stream). That repo must also bump its dependency on this artifact once released.
- Pre-existing observation (not changed here): the `OverallAuthentication` stream carries an extra `isoTimestamp` field that the V110 payload array doesn't populate at that position, so its `customParam*`/`isoTimestamp` columns are already off-by-one vs the published array. Flagging separately.